### PR TITLE
F** Add Rotation Counter

### DIFF
--- a/public/actions.js
+++ b/public/actions.js
@@ -37,10 +37,14 @@ const collectionMove = (collection, { from, to }) => {
 
 export const Init = (_, { timerId, externals, dark, lang }) => [
   {
+    timerStarted: false,
     timerStartedAt: null,
     timerDuration: 0,
     mob: [],
     goals: [],
+    rotationCount: 0,
+    currentRotation: 0,
+    totalCalculatedRotation: 0,
     settings: {
       mobOrder: 'Navigator,Driver',
       duration: 5 * 60 * 1000,

--- a/public/actions.js
+++ b/public/actions.js
@@ -629,7 +629,12 @@ export const ResumeTimer = (state, timerStartedAt = Date.now()) => [
   }),
 ];
 
-export const StartTimer = (state, { timerStartedAt, timerDuration }) => [
+export const StartTimer = (state, { timerStartedAt, timerDuration }) => {
+  if(state.currentRotation === 0){
+    state.totalCalculatedRotation = Math.ceil(state.settings.totalMobDuration / state.settings.duration);
+    state.rotationCount = 0;
+  }
+  return[
   {
     ...state,
     timerStartedAt,
@@ -641,7 +646,8 @@ export const StartTimer = (state, { timerStartedAt, timerDuration }) => [
     socketEmitter: state.externals.socketEmitter,
     timerDuration,
   }),
-];
+]
+};
 
 export const SetAllowNotification = (state, { allowNotification }) => [
   {

--- a/public/actions.js
+++ b/public/actions.js
@@ -635,6 +635,7 @@ export const StartTimer = (state, { timerStartedAt, timerDuration }) => [
     timerStartedAt,
     currentTime: timerStartedAt,
     timerDuration,
+    timerStarted: true,
   },
   effects.StartTimer({
     socketEmitter: state.externals.socketEmitter,

--- a/public/actions.js
+++ b/public/actions.js
@@ -833,6 +833,7 @@ export const UpdateSettings = state => {
       ...state,
       settings,
       pendingSettings: {},
+      rotationCount: 0,
     },
     effects.UpdateSettings({
       socketEmitter: state.externals.socketEmitter,

--- a/public/actions.js
+++ b/public/actions.js
@@ -44,6 +44,7 @@ export const Init = (_, { timerId, externals, dark, lang }) => [
     settings: {
       mobOrder: 'Navigator,Driver',
       duration: 5 * 60 * 1000,
+      totalMobDuration: 30,
     },
     expandedReorderable: null,
     timerTab: 'overview',

--- a/public/i18n/en-CA.js
+++ b/public/i18n/en-CA.js
@@ -21,6 +21,7 @@ export const en_CA = {
     startTurn: 'Start Turn',
     resume: 'Resume',
     pause: 'Pause',
+    rotationUntilRetro: 'Rotation Until Retro',
   },
 
   tabs: {
@@ -64,6 +65,7 @@ export const en_CA = {
     turnDurationInMinutes: 'Turn Duration (minutes)',
     mobRolesOrder: `${properCase(nominclature.individual)} Roles/Order`,
     positionHelpText: 'One or more comma separated list of positions',
+    totalMobbingSession: 'Total Mobbing Session (minutes)',
     localSettings: 'Local Settings',
     enableTimerSounds: 'Enable timer sounds',
     test: 'Test',

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -60,6 +60,9 @@ export const timeRemaining = props => {
               'div',
               {
                 class: {
+                  'flex': true,
+                  'items-center': true,
+                  'justify-between': true,
                 },
               },
               [

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -38,42 +38,59 @@ export const timeRemaining = props => {
           },
           [
             h(
-              'h2',
+              'div',
               {
-                class: {
-                  'text-sm': true,
-                  'font-bold': true,
-                  'uppercase': true,
-                },
+              class: {},
               },
-              text(props.lang.timeRemaining.remainingTime),
+              [
+                h(
+                  'h2',
+                  {
+                    class: {
+                      'text-sm': true,
+                      'font-bold': true,
+                      'uppercase': true,
+                    },
+                  },
+                  text(props.lang.timeRemaining.remainingTime)
+                )
+              ]
             ),
             h(
-              'span',
+              'div',
               {
                 class: {
-                  'text-6xl': true,
-                  // 'font-extrabold': true,
-                  'leading-none': true,
-                },
-                style: {
-                  fontFamily: "'Working Sans', sans-serif",
                 },
               },
-              text(timerRemainingDisplay(remainingTime)),
-            ),
-            remainingTime > 0 &&
-              deleteButton({
-                size: '24px',
-                onclick: () => [
-                  actions.Completed,
+              [
+                h(
+                  'span',
                   {
-                    isEndOfTurn: false,
-                    documentElement: document,
-                    Notification: window.Notification,
+                    class: {
+                      'text-6xl': true,
+                      // 'font-extrabold': true,
+                      'leading-none': true,
+                    },
+                    style: {
+                      fontFamily: "'Working Sans', sans-serif",
+                    },
                   },
-                ],
-              }),
+                  text(timerRemainingDisplay(remainingTime)),
+                ),
+                remainingTime > 0 &&
+                deleteButton({
+                  size: '24px',
+                  onclick: () => [
+                    actions.Completed,
+                    {
+                      isEndOfTurn: false,
+                      documentElement: document,
+                      Notification: window.Notification,
+                    },
+                  ],
+                }),
+              ],
+            ),
           ],
         ),
 

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -97,6 +97,44 @@ export const timeRemaining = props => {
           ],
         ),
 
+        h(
+          'div',
+          {
+            class: {
+              'flex': true,
+              'flex-col': true,
+              'items-center': true,
+              'justify-start': true,
+            },
+          },
+          [
+            h(
+              'h2',
+              {
+                class: {
+                  'text-sm': true,
+                  'font-bold': true,
+                  'uppercase': true,
+                },
+              },
+              text(props.lang.timeRemaining.rotationUntilRetro),
+            ),
+            h(
+              'span',
+              {
+                class: {
+                  'text-6xl': true,
+                  'leading-none': true,
+                },
+                style: {
+                  fontFamily: "'Working Sans', sans-serif",
+                },
+              },
+              text("0"),
+            ),
+          ]
+        ),
+
         !props.timerDuration &&
           button(
             {

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -14,17 +14,6 @@ export const timeRemaining = props => {
   const remainingTime = calculateTimeRemaining(props);
 
   return section({}, [
-    h(
-      'h2',
-      {
-        class: {
-          'text-sm': true,
-          'font-bold': true,
-          'uppercase': true,
-        },
-      },
-      text(props.lang.timeRemaining.remainingTime),
-    ),
 
     h(
       'div',
@@ -48,6 +37,17 @@ export const timeRemaining = props => {
             },
           },
           [
+            h(
+              'h2',
+              {
+                class: {
+                  'text-sm': true,
+                  'font-bold': true,
+                  'uppercase': true,
+                },
+              },
+              text(props.lang.timeRemaining.remainingTime),
+            ),
             h(
               'span',
               {

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -38,11 +38,11 @@ export const timeRemaining = props => {
       },
       [
         h(
-          'h3',
+          'div',
           {
             class: {
               'flex': true,
-              'flex-row': true,
+              'flex-col': true,
               'items-start': true,
               'justify-start': true,
             },

--- a/public/sections/timeRemaining.js
+++ b/public/sections/timeRemaining.js
@@ -13,6 +13,14 @@ export const timeRemaining = props => {
   const isPaused = props.timerStartedAt === null;
   const remainingTime = calculateTimeRemaining(props);
 
+  props.totalCalculatedRotation = Math.ceil(props.settings.totalMobDuration / props.settings.duration);
+  props.currentRotation = props.totalCalculatedRotation - props.rotationCount
+  if (remainingTime === 0 && props.currentRotation > 0 && props.timerStarted === true){
+    props.currentRotation = props.currentRotation - 1
+    props.rotationCount = props.rotationCount + 1
+    props.timerStarted = false
+  }
+
   return section({}, [
 
     h(
@@ -130,7 +138,7 @@ export const timeRemaining = props => {
                   fontFamily: "'Working Sans', sans-serif",
                 },
               },
-              text("0"),
+              text(props.currentRotation),
             ),
           ]
         ),

--- a/public/tabs/settings.js
+++ b/public/tabs/settings.js
@@ -142,6 +142,30 @@ export const settings = props =>
             ),
           ],
         ),
+
+        h('div', {}, text(props.lang.settings.totalMobbingSession)),
+        input({
+          name: 'setTotalMobLength',
+          maxlength: 2,
+          pattern: '[1-9]{0,2}',
+          value: toMinutes(value('totalMobDuration', props)),
+          oninput: (_, e) => {
+            e.preventDefault();
+            return [
+              actions.PendingSettingsSet,
+              {
+                key: 'totalMobDuration',
+                value: toSeconds(e.target.value),
+              },
+            ];
+          },
+
+          class: {
+            'hover:border-indigo-300': true,
+            'hover:border-b-solid': true,
+            'w-full': true,
+          },
+        }),
       ],
     ),
 


### PR DESCRIPTION
SUMMARY

# Previous Behavior:

There was no way to keep track of breaks and retro.

# New Behavior:

There is now a rotation counter to countdown how many rotation until retro. There is now an additional settings to set the total mob session to calculate the number of rotation.
